### PR TITLE
ctags file for Impala; enables tag generation for e.g., VIM

### DIFF
--- a/ctags/.ctags
+++ b/ctags/.ctags
@@ -1,0 +1,8 @@
+--langdef=impala
+--langmap=impala:.impala
+--regex-impala=/^[ \t]*type[ \t]([a-zA-Z0-9_]+)[ \t]*=.+/\1/t,typedef/
+--regex-impala=/^[ \t]*struct[ \t]([a-zA-Z0-9_]+)/\1/s,struct/
+--regex-impala=/^[ \t]*fn[ \t]([a-zA-Z0-9_]+)/\1/f,function/
+--regex-impala=/^[ \t]*let[ \t]+([a-zA-Z0-9_]+)[ \t]*=/\1/c,constant/
+--regex-impala=/^[ \t]*let[ \t]+mut[ \t]+([a-zA-Z0-9_]+)[ \t]*=/\1/v,variable/
+


### PR DESCRIPTION
I found it very convinient if your project has many files and you need to jump to a function or struct definition.