### PR TITLE
patch for working with cmake multiconfig generators

### DIFF
--- a/anydsl_runtime_cmake_multiconfig.patch
+++ b/anydsl_runtime_cmake_multiconfig.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/anydsl_runtime-config.cmake.in b/cmake/anydsl_runtime-config.cmake.in
+index 1762bdc..ab46451 100644
+--- a/cmake/anydsl_runtime-config.cmake.in
++++ b/cmake/anydsl_runtime-config.cmake.in
+@@ -267,7 +267,7 @@ function(anydsl_runtime_wrap outfiles)
+         set(_basename ${PARGS_NAME})
+     endif()
+ 
+-    set(_basepath ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${_basename})
++    set(_basepath ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${_basename})
+     set(_llfile ${_basepath}.ll)
+     set(_cfile ${_basepath}.c)
+     set(_objfile ${_basepath}.o)


### PR DESCRIPTION
Since simply replacing the use of `${CMAKE_CFG_INTDIR}` in the AnyDSL runtime CMake scripts with `$<CONFIG>` is not an option for now as this would break backwards compatibility with CMake < 3.20, this adds a patch for automatically applying the changes necessary to make the AnyDSL runtime build work with CMake >= 3.20 multiconfiguration generators.