### PR TITLE
Added RTX 3080+ support

### DIFF
--- a/patches/llvm/nvptx_feature_sm86.patch
+++ b/patches/llvm/nvptx_feature_sm86.patch
@@ -1,0 +1,38 @@
+diff --git a/llvm/lib/Target/NVPTX/NVPTX.td b/llvm/lib/Target/NVPTX/NVPTX.td
+index 2b39e9f412f7..7af927aba64e 100644
+--- a/llvm/lib/Target/NVPTX/NVPTX.td
++++ b/llvm/lib/Target/NVPTX/NVPTX.td
+@@ -57,6 +57,8 @@ def SM75 : SubtargetFeature<"sm_75", "SmVersion", "75",
+                              "Target SM 7.5">;
+ def SM80 : SubtargetFeature<"sm_80", "SmVersion", "80",
+                              "Target SM 8.0">;
++def SM86 : SubtargetFeature<"sm_86", "SmVersion", "86",
++                             "Target SM 8.6">;
+ 
+ // PTX Versions
+ def PTX32 : SubtargetFeature<"ptx32", "PTXVersion", "32",
+@@ -83,6 +85,16 @@ def PTX65 : SubtargetFeature<"ptx65", "PTXVersion", "65",
+                              "Use PTX version 6.5">;
+ def PTX70 : SubtargetFeature<"ptx70", "PTXVersion", "70",
+                              "Use PTX version 7.0">;
++def PTX71 : SubtargetFeature<"ptx71", "PTXVersion", "71",
++                             "Use PTX version 7.1">;
++def PTX72 : SubtargetFeature<"ptx72", "PTXVersion", "72",
++                             "Use PTX version 7.2">;
++def PTX73 : SubtargetFeature<"ptx73", "PTXVersion", "73",
++                             "Use PTX version 7.3">;
++def PTX74 : SubtargetFeature<"ptx74", "PTXVersion", "74",
++                             "Use PTX version 7.4">;
++def PTX75 : SubtargetFeature<"ptx75", "PTXVersion", "75",
++                             "Use PTX version 7.5">;
+ 
+ //===----------------------------------------------------------------------===//
+ // NVPTX supported processors.
+@@ -107,6 +119,7 @@ def : Proc<"sm_70", [SM70, PTX60]>;
+ def : Proc<"sm_72", [SM72, PTX61]>;
+ def : Proc<"sm_75", [SM75, PTX63]>;
+ def : Proc<"sm_80", [SM80, PTX70]>;
++def : Proc<"sm_86", [SM86, PTX71]>;
+ 
+ def NVPTXInstrInfo : InstrInfo {
+ }

--- a/setup.sh
+++ b/setup.sh
@@ -104,7 +104,7 @@ if [ "${LLVM-}" == true ]; then
         patch -p1 -i ../patches/llvm/amdgpu_icmp_fold.patch
         patch -p1 -i ../patches/llvm/nvptx_feature_ptx60.patch
     fi
-    patch -p1 -i ../patches/llvm/nvptx_feature_sm86.patch
+    patch -p1 -i ../patches/llvm/nvptx_feature_sm86.patch || true
 
     # rv
     if [ "${RV-}" == true ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -104,6 +104,7 @@ if [ "${LLVM-}" == true ]; then
         patch -p1 -i ../patches/llvm/amdgpu_icmp_fold.patch
         patch -p1 -i ../patches/llvm/nvptx_feature_ptx60.patch
     fi
+    patch -p1 -i ../patches/llvm/nvptx_feature_sm86.patch
 
     # rv
     if [ "${RV-}" == true ]; then


### PR DESCRIPTION
Added patch to support new PTX version necessary for RTX 3080 to work. Should be necessary for other RTX 30x0 as well, did not test it on them however.

Might be an good idea to add a version boundary, as the given patch only works for llvm 12 (and is a simple diff between llvm 14 & llvm 12)