### PR TITLE
Some improved dependency handling for half and LLVM.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,7 @@ set(AnyDSL_PKG_LLVM_AUTOBUILD OFF CACHE BOOL "forces the availability of LLVM to
 set(AnyDSL_PKG_RV_AUTOBUILD   OFF CACHE BOOL "forces the availability of RV to build AnyDSL packages")
 
 # Half
-if(AnyDSL_PKG_Half_AUTOBUILD AND NOT CMAKE_DISABLE_FIND_PACKAGE_Half)
-    include(cmake/half-package.cmake)
-endif()
+include(cmake/half-package.cmake)
 if(Half_DIR)
     message(STATUS "Half_DIR: ${Half_DIR}")
 else()
@@ -22,12 +20,9 @@ else()
 endif()
 
 # LLVM and clang
-if(AnyDSL_PKG_LLVM_AUTOBUILD AND NOT CMAKE_DISABLE_FIND_PACKAGE_LLVM)
-    include(cmake/llvm-package.cmake)
-endif()
-if(AnyDSL_PKG_RV_AUTOBUILD)
-    include(cmake/rv-package.cmake)
-endif()
+include(cmake/llvm-package.cmake)
+include(cmake/rv-package.cmake)
+
 find_package(LLVM QUIET)
 if(LLVM_FOUND)
     message(STATUS "LLVM_DIR: ${LLVM_DIR}")

--- a/cmake/half-package.cmake
+++ b/cmake/half-package.cmake
@@ -1,28 +1,36 @@
-
 set(AnyDSL_PKG_Half_VERSION "2.2.0" CACHE STRING "Half version of AnyDSL")
-set(AnyDSL_PKG_Half_URL "https://svn.code.sf.net/p/half/code/tags/release-${AnyDSL_PKG_Half_VERSION}" CACHE STRING "where to download Half")
+set(AnyDSL_PKG_Half_URL "https://sourceforge.net/projects/half/files/half/${AnyDSL_PKG_Half_VERSION}/half-${AnyDSL_PKG_Half_VERSION}.zip/download" CACHE STRING "where to download Half")
 
+find_package(Half QUIET)
+if(((NOT Half_FOUND) OR AnyDSL_PKG_Half_AUTOBUILD) AND NOT CMAKE_DISABLE_FIND_PACKAGE_Half)
+    if (NOT AnyDSL_PKG_Half_AUTOBUILD)
+        message(WARNING
+"AnyDSL_PKG_Half_AUTOBUILD was set to OFF, but CMake could not find Half.
+We will therefore download it anyways.
+To get rid of this warning, either set Half_DIR or enable AnyDSL_PKG_Half_AUTOBUILD.")
+    endif()
 
-include(FetchContent)
+    include(FetchContent)
 
+    FetchContent_Declare(Half
+        URL ${AnyDSL_PKG_Half_URL}
+        DOWNLOAD_NAME half.zip
+        DOWNLOAD_EXTRACT_TIMESTAMP OFF
+    )
 
-FetchContent_Declare(Half
-    URL https://sourceforge.net/projects/half/files/latest/download
-    DOWNLOAD_NAME half.zip
-)
+    message(STATUS "Make Half available ...")
+    FetchContent_GetProperties(Half)
+    if(NOT half_POPULATED)
+        FetchContent_Populate(Half)
+    endif()
 
-message(STATUS "Make Half available ...")
-FetchContent_GetProperties(Half)
-if(NOT half_POPULATED)
-    FetchContent_Populate(Half)
+    find_path(Half_DIR half.hpp
+        PATHS
+            ${half_SOURCE_DIR}
+            ${half_BINARY_DIR}
+        PATH_SUFFIXES
+            include
+            include/half
+        DOC "C++ library for half precision floating point arithmetics."
+    )
 endif()
-
-find_path(Half_DIR half.hpp
-    PATHS
-        ${half_SOURCE_DIR}
-        ${half_BINARY_DIR}
-    PATH_SUFFIXES
-        include
-        include/half
-    DOC "C++ library for half precision floating point arithmetics."
-)

--- a/cmake/half-package.cmake
+++ b/cmake/half-package.cmake
@@ -7,7 +7,8 @@ include(FetchContent)
 
 
 FetchContent_Declare(Half
-    SVN_REPOSITORY  ${AnyDSL_PKG_Half_URL}
+    URL https://sourceforge.net/projects/half/files/latest/download
+    DOWNLOAD_NAME half.zip
 )
 
 message(STATUS "Make Half available ...")

--- a/cmake/llvm-package.cmake
+++ b/cmake/llvm-package.cmake
@@ -1,44 +1,61 @@
 set(AnyDSL_PKG_LLVM_VERSION "16.0.6" CACHE STRING "LLVM version of AnyDSL")
-
 set(AnyDSL_PKG_LLVM_URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${AnyDSL_PKG_LLVM_VERSION}/llvm-project-${AnyDSL_PKG_LLVM_VERSION}.src.tar.xz" CACHE STRING "where to download LLVM")
 
-include(FetchContent)
 
-FetchContent_Declare(LLVM
-    URL  ${AnyDSL_PKG_LLVM_URL}
-    PATCH_COMMAND ${CMAKE_COMMAND} -D LLVM_VERSION=${AnyDSL_PKG_LLVM_VERSION} -P ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm/apply.cmake
-)
-set(LLVM_TARGETS_TO_BUILD "AArch64;AMDGPU;ARM;NVPTX;X86" CACHE STRING "limit targets of LLVM")
-set(LLVM_ENABLE_PROJECTS "clang;lld" CACHE STRING "enable projects of LLVM")
-set(LLVM_INCLUDE_TESTS OFF)
-set(LLVM_ENABLE_RTTI ON)
-
-message(STATUS "Make LLVM available ...")
-FetchContent_GetProperties(LLVM)
-
-if(NOT llvm_POPULATED)
-    FetchContent_Populate(LLVM)
+find_package(LLVM ${AnyDSL_PKG_LLVM_VERSION} QUIET CONFIG)
+if (NOT LLVM_FOUND AND NOT CMAKE_DISABLE_FIND_PACKAGE_LLVM)
+    find_package(LLVM QUIET CONFIG)
+    if (NOT LLVM_FOUND)
+        message(WARNING
+"LLVM not found. This is probably not what you want to do. You can either set AnyDSL_PKG_LLVM_AUTOBUILD to ON, or set LLVM_DIR to point to LLVM ${AnyDSL_PKG_LLVM_VERSION}.
+You can get also rid of this warning by setting CMAKE_DISABLE_FIND_PACKAGE_LLVM to ON.")
+    else()
+        message(WARNING
+"LLVM ${LLVM_VERSION} found, but this version does not match what AnyDSL expects. This is probably not what you want to do. You can either set AnyDSL_PKG_LLVM_AUTOBUILD to ON, or set LLVM_DIR to point to LLVM ${AnyDSL_PKG_LLVM_VERSION}.
+You can also get rid of this warning by setting AnyDSL_PKG_LLVM_VERSION to ${LLVM_VERSION}, or by enabling CMAKE_DISABLE_FIND_PACKAGE_LLVM.")
+    endif()
 endif()
 
-message(STATUS "llvm_SOURCE_DIR: ${llvm_SOURCE_DIR}")
-add_subdirectory(${llvm_SOURCE_DIR}/llvm ${llvm_BINARY_DIR})
+if(AnyDSL_PKG_LLVM_AUTOBUILD AND NOT CMAKE_DISABLE_FIND_PACKAGE_LLVM)
+    include(FetchContent)
 
-find_path(LLVM_DIR LLVMConfig.cmake
-    PATHS
-        ${llvm_BINARY_DIR}
-    PATH_SUFFIXES
-        lib/cmake/llvm
-        share/llvm/cmake
-)
+    FetchContent_Declare(LLVM
+        URL  ${AnyDSL_PKG_LLVM_URL}
+        PATCH_COMMAND ${CMAKE_COMMAND} -D LLVM_VERSION=${AnyDSL_PKG_LLVM_VERSION} -P ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm/apply.cmake
+        DOWNLOAD_EXTRACT_TIMESTAMP OFF
+    )
+    set(LLVM_TARGETS_TO_BUILD "AArch64;AMDGPU;ARM;NVPTX;X86" CACHE STRING "limit targets of LLVM")
+    set(LLVM_ENABLE_PROJECTS "clang;lld" CACHE STRING "enable projects of LLVM")
+    set(LLVM_INCLUDE_TESTS OFF)
+    set(LLVM_ENABLE_RTTI ON)
 
-find_path(Clang_DIR ClangConfig.cmake
-    PATHS
-        ${llvm_BINARY_DIR}
-        ${CMAKE_BINARY_DIR}
-        ${CMAKE_CURRENT_BINARY_DIR}
-    PATH_SUFFIXES
-        lib/cmake/clang
-        share/clang/cmake
-)
+    message(STATUS "Make LLVM available ...")
+    FetchContent_GetProperties(LLVM)
 
-set(LLVM_DIR ${llvm_BINARY_DIR}/lib/cmake/llvm)
+    if(NOT llvm_POPULATED)
+        FetchContent_Populate(LLVM)
+    endif()
+
+    message(STATUS "llvm_SOURCE_DIR: ${llvm_SOURCE_DIR}")
+    add_subdirectory(${llvm_SOURCE_DIR}/llvm ${llvm_BINARY_DIR})
+
+    find_path(LLVM_DIR LLVMConfig.cmake
+        PATHS
+            ${llvm_BINARY_DIR}
+        PATH_SUFFIXES
+            lib/cmake/llvm
+            share/llvm/cmake
+    )
+
+    find_path(Clang_DIR ClangConfig.cmake
+        PATHS
+            ${llvm_BINARY_DIR}
+            ${CMAKE_BINARY_DIR}
+            ${CMAKE_CURRENT_BINARY_DIR}
+        PATH_SUFFIXES
+            lib/cmake/clang
+            share/clang/cmake
+    )
+
+    set(LLVM_DIR ${llvm_BINARY_DIR}/lib/cmake/llvm)
+endif()

--- a/cmake/rv-package.cmake
+++ b/cmake/rv-package.cmake
@@ -1,32 +1,33 @@
 set(AnyDSL_PKG_RV_TAG "origin/master" CACHE STRING "LLVM is build with this git tag of RV")
-
 set(AnyDSL_PKG_RV_URL "https://github.com/cdl-saarland/rv" CACHE STRING "where to clone RV")
 
-include(FetchContent)
+if(AnyDSL_PKG_RV_AUTOBUILD)
+    include(FetchContent)
 
-FetchContent_Declare(RV
-    GIT_REPOSITORY ${AnyDSL_PKG_RV_URL}
-    GIT_TAG ${AnyDSL_PKG_RV_TAG}
-    GIT_SUBMODULES vecmath/sleef
-)
-message(STATUS "Make RV available ...")
-FetchContent_GetProperties(RV)
-if(NOT rv_POPULATED)
-    FetchContent_Populate(RV)
+    FetchContent_Declare(RV
+        GIT_REPOSITORY ${AnyDSL_PKG_RV_URL}
+        GIT_TAG ${AnyDSL_PKG_RV_TAG}
+        GIT_SUBMODULES vecmath/sleef
+    )
+    message(STATUS "Make RV available ...")
+    FetchContent_GetProperties(RV)
+    if(NOT rv_POPULATED)
+        FetchContent_Populate(RV)
+    endif()
+
+    message(STATUS "rv_SOURCE_DIR: ${rv_SOURCE_DIR}")
+    add_subdirectory(${rv_SOURCE_DIR} ${rv_BINARY_DIR})
+
+    find_path(RV_DIR rv-config.cmake
+        PATHS
+            ${rv_BINARY_DIR}
+            ${CMAKE_CURRENT_BINARY_DIR}
+            ${CMAKE_BINARY_DIR}
+        PATH_SUFFIXES
+            share/anydsl/cmake
+    )
+
+    #set(RV_DIR ${rv_BINARY_DIR}/share/anydsl/cmake)
+
+    message(STATUS "rv found in ${RV_DIR}")
 endif()
-
-message(STATUS "rv_SOURCE_DIR: ${rv_SOURCE_DIR}")
-add_subdirectory(${rv_SOURCE_DIR} ${rv_BINARY_DIR})
-
-find_path(RV_DIR rv-config.cmake
-    PATHS
-        ${rv_BINARY_DIR}
-        ${CMAKE_CURRENT_BINARY_DIR}
-        ${CMAKE_BINARY_DIR}
-    PATH_SUFFIXES
-        share/anydsl/cmake
-)
-
-#set(RV_DIR ${rv_BINARY_DIR}/share/anydsl/cmake)
-
-message(STATUS "rv found in ${RV_DIR}")


### PR DESCRIPTION
See #20. This forces a download of Half if it is not found, through a normal download url instead of subversion; and warns users if LLVM is not found. Handling of AnyDSL_PKG_..._AUTOBUILD was moved into the respective cmake scripts.

We should probably also merge AnyDSL/runtime#51, and generally default to the policy that warnings should only occur if something is seriously wrong in a users setup.