### PR TITLE
Commented out LLVM version warning, download half using https.

### DIFF
--- a/cmake/llvm-package.cmake
+++ b/cmake/llvm-package.cmake
@@ -2,19 +2,19 @@ set(AnyDSL_PKG_LLVM_VERSION "16.0.6" CACHE STRING "LLVM version of AnyDSL")
 set(AnyDSL_PKG_LLVM_URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${AnyDSL_PKG_LLVM_VERSION}/llvm-project-${AnyDSL_PKG_LLVM_VERSION}.src.tar.xz" CACHE STRING "where to download LLVM")
 
 
-#find_package(LLVM ${AnyDSL_PKG_LLVM_VERSION} QUIET CONFIG)
-#if (NOT LLVM_FOUND AND NOT CMAKE_DISABLE_FIND_PACKAGE_LLVM)
-#    find_package(LLVM QUIET CONFIG)
-#    if (NOT LLVM_FOUND)
-#        message(WARNING
-#"LLVM not found. This is probably not what you want to do. You can either set AnyDSL_PKG_LLVM_AUTOBUILD to ON, or set LLVM_DIR to point to LLVM ${AnyDSL_PKG_LLVM_VERSION}.
-#You can get also rid of this warning by setting CMAKE_DISABLE_FIND_PACKAGE_LLVM to ON.")
-#    else()
-#        message(WARNING
-#"LLVM ${LLVM_VERSION} found, but this version does not match what AnyDSL expects. This is probably not what you want to do. You can either set AnyDSL_PKG_LLVM_AUTOBUILD to ON, or set LLVM_DIR to point to LLVM ${AnyDSL_PKG_LLVM_VERSION}.
-#You can also get rid of this warning by setting AnyDSL_PKG_LLVM_VERSION to ${LLVM_VERSION}, or by enabling CMAKE_DISABLE_FIND_PACKAGE_LLVM.")
-#    endif()
-#endif()
+find_package(LLVM ${AnyDSL_PKG_LLVM_VERSION} QUIET CONFIG)
+if (NOT LLVM_FOUND AND NOT CMAKE_DISABLE_FIND_PACKAGE_LLVM)
+    find_package(LLVM QUIET CONFIG)
+    if (NOT LLVM_FOUND)
+        message(WARNING
+"LLVM not found. This is probably not what you want to do. You can either set AnyDSL_PKG_LLVM_AUTOBUILD to ON, or set LLVM_DIR to point to LLVM ${AnyDSL_PKG_LLVM_VERSION}.
+You can get also rid of this warning by setting CMAKE_DISABLE_FIND_PACKAGE_LLVM to ON.")
+    else()
+        message(WARNING
+"LLVM ${LLVM_VERSION} found, but this version does not match what AnyDSL expects. This is probably not what you want to do. You can either set AnyDSL_PKG_LLVM_AUTOBUILD to ON, or set LLVM_DIR to point to LLVM ${AnyDSL_PKG_LLVM_VERSION}.
+You can also get rid of this warning by setting AnyDSL_PKG_LLVM_VERSION to ${LLVM_VERSION}, or by enabling CMAKE_DISABLE_FIND_PACKAGE_LLVM.")
+    endif()
+endif()
 
 if(AnyDSL_PKG_LLVM_AUTOBUILD AND NOT CMAKE_DISABLE_FIND_PACKAGE_LLVM)
     include(FetchContent)

--- a/cmake/llvm-package.cmake
+++ b/cmake/llvm-package.cmake
@@ -2,19 +2,19 @@ set(AnyDSL_PKG_LLVM_VERSION "16.0.6" CACHE STRING "LLVM version of AnyDSL")
 set(AnyDSL_PKG_LLVM_URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${AnyDSL_PKG_LLVM_VERSION}/llvm-project-${AnyDSL_PKG_LLVM_VERSION}.src.tar.xz" CACHE STRING "where to download LLVM")
 
 
-find_package(LLVM ${AnyDSL_PKG_LLVM_VERSION} QUIET CONFIG)
-if (NOT LLVM_FOUND AND NOT CMAKE_DISABLE_FIND_PACKAGE_LLVM)
-    find_package(LLVM QUIET CONFIG)
-    if (NOT LLVM_FOUND)
-        message(WARNING
-"LLVM not found. This is probably not what you want to do. You can either set AnyDSL_PKG_LLVM_AUTOBUILD to ON, or set LLVM_DIR to point to LLVM ${AnyDSL_PKG_LLVM_VERSION}.
-You can get also rid of this warning by setting CMAKE_DISABLE_FIND_PACKAGE_LLVM to ON.")
-    else()
-        message(WARNING
-"LLVM ${LLVM_VERSION} found, but this version does not match what AnyDSL expects. This is probably not what you want to do. You can either set AnyDSL_PKG_LLVM_AUTOBUILD to ON, or set LLVM_DIR to point to LLVM ${AnyDSL_PKG_LLVM_VERSION}.
-You can also get rid of this warning by setting AnyDSL_PKG_LLVM_VERSION to ${LLVM_VERSION}, or by enabling CMAKE_DISABLE_FIND_PACKAGE_LLVM.")
-    endif()
-endif()
+#find_package(LLVM ${AnyDSL_PKG_LLVM_VERSION} QUIET CONFIG)
+#if (NOT LLVM_FOUND AND NOT CMAKE_DISABLE_FIND_PACKAGE_LLVM)
+#    find_package(LLVM QUIET CONFIG)
+#    if (NOT LLVM_FOUND)
+#        message(WARNING
+#"LLVM not found. This is probably not what you want to do. You can either set AnyDSL_PKG_LLVM_AUTOBUILD to ON, or set LLVM_DIR to point to LLVM ${AnyDSL_PKG_LLVM_VERSION}.
+#You can get also rid of this warning by setting CMAKE_DISABLE_FIND_PACKAGE_LLVM to ON.")
+#    else()
+#        message(WARNING
+#"LLVM ${LLVM_VERSION} found, but this version does not match what AnyDSL expects. This is probably not what you want to do. You can either set AnyDSL_PKG_LLVM_AUTOBUILD to ON, or set LLVM_DIR to point to LLVM ${AnyDSL_PKG_LLVM_VERSION}.
+#You can also get rid of this warning by setting AnyDSL_PKG_LLVM_VERSION to ${LLVM_VERSION}, or by enabling CMAKE_DISABLE_FIND_PACKAGE_LLVM.")
+#    endif()
+#endif()
 
 if(AnyDSL_PKG_LLVM_AUTOBUILD AND NOT CMAKE_DISABLE_FIND_PACKAGE_LLVM)
     include(FetchContent)

--- a/setup.sh
+++ b/setup.sh
@@ -150,7 +150,12 @@ else
 fi
 
 if [ ! -e "${CUR}/half" ]; then
-    svn checkout svn://svn.code.sf.net/p/half/code/trunk half
+    mkdir half
+    cd half
+    wget https://sourceforge.net/projects/half/files/latest/download -O half.zip
+    unzip half.zip
+    rm half.zip
+    cd ${CUR}
 fi
 
 # source this file to put artic, impala, and clang in path


### PR DESCRIPTION
This is only relevant for people using the cmake based setup using prebuild LLVM. An alternative could be matching the major version only.