### PR TITLE
[CMake] Bugfix: do not look for random versions of LLVM.

### DIFF
--- a/cmake/llvm-package.cmake
+++ b/cmake/llvm-package.cmake
@@ -3,21 +3,23 @@ set(AnyDSL_PKG_LLVM_URL "https://github.com/llvm/llvm-project/releases/download/
 
 # LLVM's version handling requires exact matches of major.minor to ensure API compatibility
 # however, LLVM does not support version ranges for CMake's find_package() command
-string(REGEX MATCH "^([0-9]+)\.([0-9]+)" AnyDSL_PKG_LLVM_VERSION_MAJOR_MINOR ${AnyDSL_PKG_LLVM_VERSION})
-set(AnyDSL_PKG_LLVM_VERSION_MAJOR ${CMAKE_MATCH_1})
-set(AnyDSL_PKG_LLVM_VERSION_MINOR ${CMAKE_MATCH_2})
-foreach(_minor_version RANGE 0 ${AnyDSL_PKG_LLVM_VERSION_MINOR})
-    find_package(LLVM ${AnyDSL_PKG_LLVM_VERSION_MAJOR}.${_minor_version} CONFIG QUIET)
-endforeach()
+string(REGEX MATCH "^[0-9]+\.[0-9]+" AnyDSL_PKG_LLVM_VERSION_MAJOR_MINOR ${AnyDSL_PKG_LLVM_VERSION})
+
+set(AnyDSL_PKG_LLVM_DIR ${LLVM_DIR})
+find_package(LLVM ${AnyDSL_PKG_LLVM_VERSION_MAJOR_MINOR} CONFIG QUIET)
+if (NOT LLVM_FOUND)
+    set(LLVM_DIR ${AnyDSL_PKG_LLVM_DIR})
+endif()
+
 if (NOT LLVM_FOUND AND NOT CMAKE_DISABLE_FIND_PACKAGE_LLVM)
-	find_package(LLVM CONFIG QUIET)
+    find_package(LLVM CONFIG QUIET)
     if (NOT LLVM_FOUND)
         message(WARNING
 "LLVM not found. This is probably not what you want to do. You can either set AnyDSL_PKG_LLVM_AUTOBUILD to ON, or set LLVM_DIR to point to LLVM ${AnyDSL_PKG_LLVM_VERSION}.
 You can get also rid of this warning by setting CMAKE_DISABLE_FIND_PACKAGE_LLVM to ON.")
     else()
         message(WARNING
-		"LLVM ${LLVM_VERSION} found, but this version does not match what AnyDSL expects. This is probably not what you want to do. You can either set AnyDSL_PKG_LLVM_AUTOBUILD to ON, or set LLVM_DIR to point to LLVM ${AnyDSL_PKG_LLVM_VERSION_MAJOR}.
+"LLVM ${LLVM_VERSION} found, but this version does not match what AnyDSL expects. This is probably not what you want to do. You can either set AnyDSL_PKG_LLVM_AUTOBUILD to ON, or set LLVM_DIR to point to LLVM ${AnyDSL_PKG_LLVM_VERSION_MAJOR_MINOR}.
 You can also get rid of this warning by setting AnyDSL_PKG_LLVM_VERSION to ${LLVM_VERSION}, or by enabling CMAKE_DISABLE_FIND_PACKAGE_LLVM.")
     endif()
 endif()


### PR DESCRIPTION
find_package(LLVM) will alter LLVM_DIR if no candidate is found. As a consequence, if the first call does not find the correct version of LLVM, subsequent calls will not be able to consider the path manually supplied by the user. We can fix this by restoring the original value of LLVM_DIR if this happens.

LLVM's minor version number is effectively unused right now, so it's fine to only check for one particular major.minor combination and move to the default case when we don't find a valid version immediately.